### PR TITLE
Bump kemitix-maven-tiles from 2.2.0 to 2.3.0

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -19,7 +19,7 @@
 
     <properties>
         <tiles-maven-plugin.version>2.13</tiles-maven-plugin.version>
-        <kemitix-maven-tiles.version>2.2.0</kemitix-maven-tiles.version>
+        <kemitix-maven-tiles.version>2.3.0</kemitix-maven-tiles.version>
         <kemitix-checkstyle.version>4.1.1</kemitix-checkstyle.version>
 
         <digraph-dependency.basePackage>net.kemitix.naolo</digraph-dependency.basePackage>


### PR DESCRIPTION
Added

   - Add scala-lang tile (#117)

Dependencies

   - Bump spotbugs from 3.1.11 to 3.1.12 (#115)
   - Bump pitest-maven from 1.4.5 to 1.4.6 (#116)