### PR TITLE
build(deps): bump quarkus-maven-plugin from 1.3.2.Final to 1.4.1.Final

### DIFF
--- a/runner-quarkus/pom.xml
+++ b/runner-quarkus/pom.xml
@@ -12,7 +12,7 @@
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus-plugin.version>1.3.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.4.1.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-universe-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
     <quarkus.platform.version>1.3.2.Final</quarkus.platform.version>


### PR DESCRIPTION
Bumps quarkus-maven-plugin from 1.3.2.Final to 1.4.1.Final.

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>